### PR TITLE
Do not roll-up 'task.all' search type into 'task'

### DIFF
--- a/src/data-collector/data-collector.ts
+++ b/src/data-collector/data-collector.ts
@@ -244,7 +244,7 @@ export const getDateFromTask = (
   const searchType = query.type;
 
   let strRegex = query.target;
-  if (searchType === SearchType.Task) {
+  if (searchType === SearchType.Task || searchType === SearchType.TaskAll) {
     strRegex = '\\[[\\sx]\\]\\s' + strRegex;
   } else if (searchType === SearchType.TaskDone) {
     strRegex = '\\[x\\]\\s' + strRegex;
@@ -664,7 +664,7 @@ export const collectDataFromTask = (
   const searchType = query.type;
 
   let strRegex = query.target;
-  if (searchType === SearchType.Task) {
+  if (searchType === SearchType.Task || searchType === SearchType.TaskAll) {
     strRegex = '\\[[\\sx]\\]\\s' + strRegex;
   } else if (searchType === SearchType.TaskDone) {
     strRegex = '\\[x\\]\\s' + strRegex;

--- a/src/main.ts
+++ b/src/main.ts
@@ -328,6 +328,7 @@ export default class Tracker extends Plugin {
             type === SearchType.Text ||
             type === SearchType.DataviewField ||
             type === SearchType.Task ||
+            type === SearchType.TaskAll ||
             type === SearchType.TaskDone ||
             type === SearchType.TaskNotDone
           ) {
@@ -399,6 +400,7 @@ export default class Tracker extends Plugin {
                   );
                   break;
                 case SearchType.Task:
+                case SearchType.TaskAll:
                 case SearchType.TaskDone:
                 case SearchType.TaskNotDone:
                   xDate = collecting.getDateFromTask(
@@ -558,6 +560,7 @@ export default class Tracker extends Plugin {
           if (
             content &&
             (query.type === SearchType.Task ||
+              query.type === SearchType.TaskAll ||
               query.type === SearchType.TaskDone ||
               query.type === SearchType.TaskNotDone)
           ) {

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -9,6 +9,7 @@ export enum SearchType {
   Table = 'table',
   FileMeta = 'fileMeta',
   Task = 'task',
+  TaskAll = 'task.all',
   TaskDone = 'task.done',
   TaskNotDone = 'task.notdone',
 }

--- a/src/parser/yaml-parser.helper.ts
+++ b/src/parser/yaml-parser.helper.ts
@@ -286,7 +286,7 @@ export const getSearchTypes = (
       case 'task':
         return SearchType.Task;
       case 'task.all':
-        return SearchType.Task;
+        return SearchType.TaskAll;
       case 'task.done':
         return SearchType.TaskDone;
       case 'task.notdone':


### PR DESCRIPTION
- Explicitly reference task.all search type instead of rolling up into 'task'